### PR TITLE
Rename user table from `users` to `User`

### DIFF
--- a/backend/user-service/jest.config.js
+++ b/backend/user-service/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testPathIgnorePatterns: ["tests/utils", "tests/payloads", "dist"],
 };

--- a/backend/user-service/models/user-model.ts
+++ b/backend/user-service/models/user-model.ts
@@ -1,91 +1,134 @@
-import { QueryResult } from 'pg';
-import pool from '../psql';
+import { QueryResult } from "pg";
+import pool from "../psql";
 
 async function getAllUsers(): Promise<any[]> {
-    try {
-        const result: QueryResult = await pool.query('SELECT * FROM users.users');
-        return result.rows;
-    } catch (error) {
-        throw error;
-    }
+  try {
+    const result: QueryResult = await pool.query('SELECT * FROM users."User"');
+    return result.rows;
+  } catch (error) {
+    throw error;
+  }
 }
 
 async function getUserByUserId(uid: number): Promise<QueryResult> {
-    try {
-        const result: QueryResult = await pool.query('SELECT * FROM users.users WHERE uid = $1', [uid]);
-        return result;
-    } catch (error) {
-        throw error;
-    }
+  try {
+    const result: QueryResult = await pool.query(
+      'SELECT * FROM users."User" WHERE uid = $1',
+      [uid]
+    );
+    return result;
+  } catch (error) {
+    throw error;
+  }
 }
 
 async function getUserByEmail(email: string): Promise<QueryResult> {
-    try {
-        const result: QueryResult = await pool.query('SELECT * FROM users.users WHERE email = $1', [email]);
-        return result;
-    } catch (error) {
-        throw error;
-    }
+  try {
+    const result: QueryResult = await pool.query(
+      'SELECT * FROM users."User" WHERE email = $1',
+      [email]
+    );
+    return result;
+  } catch (error) {
+    throw error;
+  }
 }
 
-async function updateUser(uid: number, name: string, major: string, course: string, email: string, hash: string, role: string): Promise<void> {
-    try {
-        await pool.query(`UPDATE users.users SET name = $2, major = $3, course = $4, email = $5, password = $6, role = $7
-            WHERE uid = $1`, [uid, name, major, course, email, hash, role]);
-    } catch (error) {
-        throw error;
-    }
+async function updateUser(
+  uid: number,
+  name: string,
+  major: string,
+  course: string,
+  email: string,
+  hash: string,
+  role: string
+): Promise<void> {
+  try {
+    await pool.query(
+      `UPDATE users."User" SET name = $2, major = $3, course = $4, email = $5, password = $6, role = $7
+            WHERE uid = $1`,
+      [uid, name, major, course, email, hash, role]
+    );
+  } catch (error) {
+    throw error;
+  }
 }
 
-async function createNewUser(name: string, major: string, course: string, email: string, hash: string, role: string): Promise<number> {
-    try {
-        const result: QueryResult = await pool.query(`INSERT INTO users.users (name, major, course, email, password, role)
+async function createNewUser(
+  name: string,
+  major: string,
+  course: string,
+  email: string,
+  hash: string,
+  role: string
+): Promise<number> {
+  try {
+    const result: QueryResult = await pool.query(
+      `INSERT INTO users."User" (name, major, course, email, password, role)
             VALUES ($1, $2, $3, $4, $5, $6)
-            RETURNING uid;`, [name, major, course, email, hash, role]);
-        const uid: number = result.rows[0].uid;
-        console.log(uid);
-        return uid;
-    } catch (error) {
-        throw error;
-    }
+            RETURNING uid;`,
+      [name, major, course, email, hash, role]
+    );
+    const uid: number = result.rows[0].uid;
+    console.log(uid);
+    return uid;
+  } catch (error) {
+    throw error;
+  }
 }
 
 async function updateUserPassword(uid: number, hash: string): Promise<void> {
-    try {
-        await pool.query(`UPDATE users.users SET password = $2
-            WHERE uid = $1`, [uid, hash]);
-    } catch (error) {
-        throw error;
-    }
+  try {
+    await pool.query(
+      `UPDATE users."User" SET password = $2
+            WHERE uid = $1`,
+      [uid, hash]
+    );
+  } catch (error) {
+    throw error;
+  }
 }
 
-async function updateUserInfo(uid: number, email: string, name: string, major: string, course: string, role: string): Promise<void> {
-    try {
-        await pool.query(`UPDATE users.users SET email = $2, name = $3, major = $4, course = $5, role = $6
-            WHERE uid = $1`, [uid, email, name, major, course, role]);
-    } catch (error) {
-        throw error;
-    }
+async function updateUserInfo(
+  uid: number,
+  email: string,
+  name: string,
+  major: string,
+  course: string,
+  role: string
+): Promise<void> {
+  try {
+    await pool.query(
+      `UPDATE users."User" SET email = $2, name = $3, major = $4, course = $5, role = $6
+            WHERE uid = $1`,
+      [uid, email, name, major, course, role]
+    );
+  } catch (error) {
+    throw error;
+  }
 }
 
 async function deleteUser(uid: number): Promise<QueryResult> {
-    try {
-        const result: QueryResult = await pool.query(`DELETE FROM users.users WHERE uid = $1`, [uid]);
-        return result;
-    } catch (error) {
-        throw error;
-    }
+  try {
+    const result: QueryResult = await pool.query(
+      `DELETE FROM users."User" WHERE uid = $1`,
+      [uid]
+    );
+    return result;
+  } catch (error) {
+    throw error;
+  }
 }
 
-const db =  {
-    getAllUsers,
-    getUserByUserId,
-    getUserByEmail,
-    updateUser,
-    createNewUser,
-    updateUserPassword,
-    updateUserInfo,
-    deleteUser,
+const db = {
+  getAllUsers,
+  getUserByUserId,
+  getUserByEmail,
+  updateUser,
+  createNewUser,
+  updateUserPassword,
+  updateUserInfo,
+  deleteUser,
 };
 
 export default db;

--- a/backend/user-service/package.json
+++ b/backend/user-service/package.json
@@ -1,4 +1,26 @@
 {
+  "name": "user-service",
+  "version": "1.0.0",
+  "description": "A Microservice that provides API for frontend to perform CRUD operations on the users database",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "nodemon index.ts",
+    "build": "tsc -p .",
+    "start": "node dist/index.js",
+    "lint": "eslint ./**/*.ts ./*.ts --ext .ts && prettier --check --ignore-path .gitignore .",
+    "lint:autofix": "eslint ./**/*.ts ./*.ts --ext .ts --fix --ignore-path .gitignore . && prettier --write --ignore-path .gitignore .",
+    "test": "jest --coverage --verbose"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.3",
+    "jsonwebtoken": "^9.0.2",
+    "pg": "^8.11.3"
+  },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/cookie-parser": "^1.4.7",
@@ -13,33 +35,11 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "jest": "^29.7.0",
+    "nodemon": "^3.1.0",
     "prettier": "^3.2.5",
     "supertest": "^6.3.4",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.2.1",
     "typescript": "^5.4.2"
-  },
-  "name": "user-service",
-  "version": "1.0.0",
-  "description": "A Microservice that provides API for frontend to perform CRUD operations on the users database",
-  "main": "index.js",
-  "author": "Hoang Huu Chinh",
-  "license": "MIT",
-  "dependencies": {
-    "bcrypt": "^5.1.1",
-    "cookie-parser": "^1.4.6",
-    "cors": "^2.8.5",
-    "dotenv": "^16.4.5",
-    "express": "^4.18.3",
-    "jsonwebtoken": "^9.0.2",
-    "pg": "^8.11.3"
-  },
-  "scripts": {
-    "dev": "ts-node index.ts",
-    "build": "tsc -p .",
-    "start": "node dist/index.js",
-    "lint": "eslint ./**/*.ts ./*.ts --ext .ts && prettier --check --ignore-path .gitignore .",
-    "lint:autofix": "eslint ./**/*.ts ./*.ts --ext .ts --fix --ignore-path .gitignore . && prettier --write --ignore-path .gitignore .",
-    "test": "jest --coverage --verbose"
   }
 }

--- a/backend/user-service/psql.ts
+++ b/backend/user-service/psql.ts
@@ -1,19 +1,22 @@
-import { Pool } from 'pg';
-import dotenv from 'dotenv';
+import { Pool } from "pg";
+import dotenv from "dotenv";
 
 dotenv.config();
 
-const pool = new Pool({
-    host     : process.env.PSQL_HOSTNAME,
-    database : process.env.PSQL_DATABASE,
-    user     : process.env.PSQL_USERNAME,
-    password : process.env.PSQL_PASSWORD,
-    port     : parseInt(process.env.PSQL_PORT || '5432')
-});
+const pool =
+  process.env.NODE_ENV === "test"
+    ? new Pool()
+    : new Pool({
+        host: process.env.PSQL_HOSTNAME,
+        database: process.env.PSQL_DATABASE,
+        user: process.env.PSQL_USERNAME,
+        password: process.env.PSQL_PASSWORD,
+        port: parseInt(process.env.PSQL_PORT || "5432"),
+      });
 
 const createUserTableQueryIfNotExist = `
         CREATE SCHEMA IF NOT EXISTS users;
-        CREATE TABLE IF NOT EXISTS users.users (
+        CREATE TABLE IF NOT EXISTS users."User" (
             uid SERIAL PRIMARY KEY,
             email VARCHAR(255) NOT NULL,
             name VARCHAR(255) NOT NULL,
@@ -23,14 +26,16 @@ const createUserTableQueryIfNotExist = `
             role VARCHAR(60) NOT NULL
         );
   `;
-  
-pool.query(createUserTableQueryIfNotExist)
-.catch((err) => {
-    console.error('Error creating table:', err);
-})
 
-pool.connect()
-    .then(() => console.log('Connected to the user microservice psql database'))
-    .catch(err => console.error('Error connecting to the user microservce database', err));
+pool.query(createUserTableQueryIfNotExist).catch((err) => {
+  console.error("Error creating table:", err);
+});
+
+pool
+  .connect()
+  .then(() => console.log("Connected to the user microservice psql database"))
+  .catch((err) =>
+    console.error("Error connecting to the user microservce database", err)
+  );
 
 export default pool;

--- a/backend/user-service/tests/unit/controller/user-controller.test.ts
+++ b/backend/user-service/tests/unit/controller/user-controller.test.ts
@@ -1,11 +1,11 @@
 import supertest from "supertest";
 import bcrypt from "bcrypt";
-import jwt from 'jsonwebtoken';
+import jwt from "jsonwebtoken";
 import db from "../../../models/user-model";
 import createUnitTestServer from "../../utils/create-test-server-utils";
 import { getCreateUserRequestBody } from "../../payload/request/create-user-request-body";
-import { getLoginUserRequestBody } from '../../payload/request/login-user-request-body';
-import { getGetUserRequestBody } from '../../payload/request/get-user-request-body';
+import { getLoginUserRequestBody } from "../../payload/request/login-user-request-body";
+import { getGetUserRequestBody } from "../../payload/request/get-user-request-body";
 import { QueryResult } from "pg";
 import { getLoginUserResponseBody } from "../../payload/response/login-user-response-body";
 import { getCreateUserResponseBody } from "../../payload/response/create-user-response-body";
@@ -17,12 +17,12 @@ import { getUpdateUserPasswordRequestBody } from "../../payload/request/update-u
 import { getUpdateUserInfoRequestBody } from "../../payload/request/update-user-info-request-body";
 import { getDeleteUserRequestBody } from "../../payload/request/delete-user-request-body";
 
-jest.mock("../../../psql", () => {
-  return {
-    query: jest.fn(),
-    connect: jest.fn(),
-  };
-});
+process.env.NODE_ENV = "test";
+
+jest.mock("../../../psql", () => ({
+  query: jest.fn(),
+  connect: jest.fn(),
+}));
 
 describe("Unit Tests for /user/register endpoint", () => {
   const app = createUnitTestServer();
@@ -164,7 +164,7 @@ describe("Unit Tests for /user/register endpoint", () => {
   });
 });
 
-describe('Unit Tests for /user/login endpoint', () => {
+describe("Unit Tests for /user/login endpoint", () => {
   const app = createUnitTestServer();
   let reqBody: any;
 
@@ -177,18 +177,18 @@ describe('Unit Tests for /user/login endpoint', () => {
   });
 
   describe("Given a valid request body to login a user", () => {
-    it('Should return 200 and a token', async () => {
+    it("Should return 200 and a token", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByEmail').mockResolvedValue({ rows: [getLoginUserResponseBody()] } as unknown as QueryResult<any>);
+      jest.spyOn(db, "getUserByEmail").mockResolvedValue({
+        rows: [getLoginUserResponseBody()],
+      } as unknown as QueryResult<any>);
       bcrypt.compare = jest.fn().mockResolvedValue(true);
-      jwt.sign = jest.fn().mockResolvedValue('fake_token');
-      process.env.JWT_SECRET_KEY = 'secretkey';
+      jwt.sign = jest.fn().mockResolvedValue("fake_token");
+      process.env.JWT_SECRET_KEY = "secretkey";
 
       // Act
-      const response = await supertest(app)
-        .post('/user/login')
-        .send(reqBody);
-  
+      const response = await supertest(app).post("/user/login").send(reqBody);
+
       // Assert
       expect(response.body).toEqual({ user: getLoginUserResponseBody() });
       expect(response.status).toBe(200);
@@ -196,52 +196,51 @@ describe('Unit Tests for /user/login endpoint', () => {
   });
 
   describe("Given a non-existing email", () => {
-    it('Should return 400 and an error message', async () => {
+    it("Should return 400 and an error message", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByEmail').mockResolvedValue({ rows: [] } as unknown as QueryResult<any>);
+      jest
+        .spyOn(db, "getUserByEmail")
+        .mockResolvedValue({ rows: [] } as unknown as QueryResult<any>);
 
       // Act
-      const response = await supertest(app)
-        .post('/user/login')
-        .send(reqBody);
-      
+      const response = await supertest(app).post("/user/login").send(reqBody);
+
       // Assert
-      expect(response.body).toEqual({ error: 'User does not exist.' });
+      expect(response.body).toEqual({ error: "User does not exist." });
       // expect(response.status).toBe(400);
     });
   });
 
   describe("Given an incorrect password", () => {
-    it('Should return 400 and an error message', async () => {
+    it("Should return 400 and an error message", async () => {
       // Arrange
-      reqBody.password = 'wrongpassword'
-      jest.spyOn(db, 'getUserByEmail').mockResolvedValue({ rows: [{ email: reqBody.email, password: 'hashedpassword' }] } as unknown as QueryResult<any>);
+      reqBody.password = "wrongpassword";
+      jest.spyOn(db, "getUserByEmail").mockResolvedValue({
+        rows: [{ email: reqBody.email, password: "hashedpassword" }],
+      } as unknown as QueryResult<any>);
       bcrypt.compare = jest.fn().mockResolvedValue(false);
-      
-      
+
       // Act
-      const response = await supertest(app)
-        .post('/user/login')
-        .send(reqBody);
-  
+      const response = await supertest(app).post("/user/login").send(reqBody);
+
       // Assert
-      expect(response.body).toEqual({ error: 'Incorrect password.' });
+      expect(response.body).toEqual({ error: "Incorrect password." });
       // expect(response.status).toBe(400);
     });
   });
 
   describe("Given JWT secret key is not defined", () => {
-    it('Should return a 500 status and an error message', async () => {
+    it("Should return a 500 status and an error message", async () => {
       // Mock process.env.JWT_SECRET_KEY to be undefined
-      jest.spyOn(db, 'getUserByEmail').mockResolvedValue({ rows: [getLoginUserResponseBody()] } as unknown as QueryResult<any>);
+      jest.spyOn(db, "getUserByEmail").mockResolvedValue({
+        rows: [getLoginUserResponseBody()],
+      } as unknown as QueryResult<any>);
       bcrypt.compare = jest.fn().mockResolvedValue(true);
       delete process.env.JWT_SECRET_KEY;
-  
+
       // Act
-      const response = await supertest(app)
-        .post('/user/login')
-        .send(reqBody);
-  
+      const response = await supertest(app).post("/user/login").send(reqBody);
+
       // Assert
       expect(response.body).toEqual({ error: "Internal server error." });
       // expect(response.status).toBe(500);
@@ -249,24 +248,26 @@ describe('Unit Tests for /user/login endpoint', () => {
   });
 
   describe("Given an error while checking the password", () => {
-    it('Should return 500 and an error message', async () => {
+    it("Should return 500 and an error message", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByEmail').mockResolvedValue({ rows: [{ email: reqBody.email, password: 'hashedpassword' }] } as unknown as QueryResult<any>);
-      bcrypt.compare = jest.fn().mockRejectedValue(new Error('Error checking password.'));
+      jest.spyOn(db, "getUserByEmail").mockResolvedValue({
+        rows: [{ email: reqBody.email, password: "hashedpassword" }],
+      } as unknown as QueryResult<any>);
+      bcrypt.compare = jest
+        .fn()
+        .mockRejectedValue(new Error("Error checking password."));
 
       // Act
-      const response = await supertest(app)
-        .post('/user/login')
-        .send(reqBody);
-  
+      const response = await supertest(app).post("/user/login").send(reqBody);
+
       // Assert
-      expect(response.body).toEqual({ message: 'Error checking password.' });
+      expect(response.body).toEqual({ message: "Error checking password." });
       // expect(response.status).toBe(500);
     });
   });
 });
 
-describe('Unit Tests for /user/getUserByUserId endpoint', () => {
+describe("Unit Tests for /user/getUserByUserId endpoint", () => {
   const app = createUnitTestServer();
   let reqBody: any;
 
@@ -279,52 +280,58 @@ describe('Unit Tests for /user/getUserByUserId endpoint', () => {
   });
 
   describe("Given a valid user ID", () => {
-    it('Should return the user object', async () => {
+    it("Should return the user object", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByUserId').mockResolvedValue({ rows: [getGetUserResponseBody()] } as unknown as QueryResult<any>);
-  
+      jest.spyOn(db, "getUserByUserId").mockResolvedValue({
+        rows: [getGetUserResponseBody()],
+      } as unknown as QueryResult<any>);
+
       // Act
       const response = await supertest(app)
-        .get('/user/getUserByUserId')
+        .get("/user/getUserByUserId")
         .send(reqBody);
-  
+
       // Assert
       expect(response.body).toEqual(getGetUserResponseBody());
     });
   });
 
   describe("Given a non-existing user ID", () => {
-    it('Should return an error message', async () => {
+    it("Should return an error message", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByUserId').mockResolvedValue({ rows: [] } as unknown as QueryResult<any>);
-  
+      jest
+        .spyOn(db, "getUserByUserId")
+        .mockResolvedValue({ rows: [] } as unknown as QueryResult<any>);
+
       // Act
       const response = await supertest(app)
-        .get('/user/getUserByUserId')
+        .get("/user/getUserByUserId")
         .send(reqBody);
-  
+
       // Assert
-      expect(response.body).toEqual({ error: 'User does not exist.' });
+      expect(response.body).toEqual({ error: "User does not exist." });
     });
   });
 
   describe("Given an error while fetching user", () => {
-    it('Should return an error message', async () => {
+    it("Should return an error message", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByUserId').mockRejectedValue(new Error('Database error'));
-  
+      jest
+        .spyOn(db, "getUserByUserId")
+        .mockRejectedValue(new Error("Database error"));
+
       // Act
       const response = await supertest(app)
-        .get('/user/getUserByUserId')
+        .get("/user/getUserByUserId")
         .send(reqBody);
-  
+
       // Assert
-      expect(response.body).toEqual({ message: 'Error getting user by uid.' });
+      expect(response.body).toEqual({ message: "Error getting user by uid." });
     });
   });
 });
 
-describe('Unit Tests for /user/getUserByEmail endpoint', () => {
+describe("Unit Tests for /user/getUserByEmail endpoint", () => {
   const app = createUnitTestServer();
   let reqBody: any;
 
@@ -336,107 +343,111 @@ describe('Unit Tests for /user/getUserByEmail endpoint', () => {
     jest.clearAllMocks();
   });
 
-  it('Should return user details if user exists', async () => {
-    jest.spyOn(db, 'getUserByEmail').mockResolvedValue({ rows: [getGetUserByEmailResponseBody()] } as unknown as QueryResult<any>);
+  it("Should return user details if user exists", async () => {
+    jest.spyOn(db, "getUserByEmail").mockResolvedValue({
+      rows: [getGetUserByEmailResponseBody()],
+    } as unknown as QueryResult<any>);
 
     // Act
-    const response = await supertest(app)
-      .get(`/user/getUserByEmail`);
+    const response = await supertest(app).get(`/user/getUserByEmail`);
 
     // Assert
     expect(response.body).toEqual(getGetUserByEmailResponseBody());
     expect(response.status).toBe(200);
   });
 
-  it('Should return an error message if user does not exist', async () => {
+  it("Should return an error message if user does not exist", async () => {
     // Arrange
-    reqBody.email = 'nonexistent@example.com';
-    jest.spyOn(db, 'getUserByEmail').mockResolvedValue({ rows: [] } as unknown as QueryResult<any>);
+    reqBody.email = "nonexistent@example.com";
+    jest
+      .spyOn(db, "getUserByEmail")
+      .mockResolvedValue({ rows: [] } as unknown as QueryResult<any>);
 
     // Act
-    const response = await supertest(app)
-      .get(`/user/getUserByEmail`);
+    const response = await supertest(app).get(`/user/getUserByEmail`);
 
     // Assert
-    expect(response.body).toEqual({ error: 'User does not exist.' });
+    expect(response.body).toEqual({ error: "User does not exist." });
     // expect(response.status).toBe(404);
   });
 
-  it('Should return an error message if there is an error getting user by email', async () => {
+  it("Should return an error message if there is an error getting user by email", async () => {
     // Arrange
-    jest.spyOn(db, 'getUserByEmail').mockRejectedValue(new Error('Database error'));
+    jest
+      .spyOn(db, "getUserByEmail")
+      .mockRejectedValue(new Error("Database error"));
 
     // Act
-    const response = await supertest(app)
-      .get(`/user/getUserByEmail`);
+    const response = await supertest(app).get(`/user/getUserByEmail`);
 
     // Assert
-    expect(response.body).toEqual({ message: 'Error getting user by email.' });
+    expect(response.body).toEqual({ message: "Error getting user by email." });
     // expect(response.status).toBe(500);
   });
 });
 
-describe('Unit Tests for /user/getAllUsers endpoint', () => {
+describe("Unit Tests for /user/getAllUsers endpoint", () => {
   const app = createUnitTestServer();
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('If there are users, should return all users', async () => {
+  it("If there are users, should return all users", async () => {
     // Arrange
 
-    jest.spyOn(db, 'getAllUsers').mockResolvedValue(getGetAllUsersResponseBody());
+    jest
+      .spyOn(db, "getAllUsers")
+      .mockResolvedValue(getGetAllUsersResponseBody());
 
     // Act
-    const response = await supertest(app)
-      .get('/user/getAllUsers');
+    const response = await supertest(app).get("/user/getAllUsers");
 
     // Assert
     expect(response.body).toEqual(getGetAllUsersResponseBody());
     expect(response.status).toBe(200);
   });
 
-  it('If there are no users, should return empty', async () => {
+  it("If there are no users, should return empty", async () => {
     // Arrange
 
-    jest.spyOn(db, 'getAllUsers').mockResolvedValue([]);
+    jest.spyOn(db, "getAllUsers").mockResolvedValue([]);
 
     // Act
-    const response = await supertest(app)
-      .get('/user/getAllUsers');
+    const response = await supertest(app).get("/user/getAllUsers");
 
     // Assert
     expect(response.body).toEqual([]);
     expect(response.status).toBe(200);
   });
 
-  it('Should return an error message if there is an error getting all users', async () => {
+  it("Should return an error message if there is an error getting all users", async () => {
     // Arrange
-    jest.spyOn(db, 'getAllUsers').mockRejectedValue(new Error('Database error'));
+    jest
+      .spyOn(db, "getAllUsers")
+      .mockRejectedValue(new Error("Database error"));
 
     // Act
-    const response = await supertest(app)
-      .get('/user/getAllUsers');
+    const response = await supertest(app).get("/user/getAllUsers");
 
     // Assert
-    expect(response.body).toEqual({ message: 'Error getting all users.' });
+    expect(response.body).toEqual({ message: "Error getting all users." });
     // expect(response.status).toBe(500);
   });
 });
 
-describe('Unit Tests for /user/updateUserPassword endpoint', () => {
+describe("Unit Tests for /user/updateUserPassword endpoint", () => {
   const app = createUnitTestServer();
   let reqBody: any;
-  const user = { 
+  const user = {
     uid: 1,
-    email: 'test@example.com',
-    password: 'password12345',
-    name: 'Test',
-    major: 'Computer Science',
-    course: 'CS1101S',
-    role: 'student',
-   };
+    email: "test@example.com",
+    password: "password12345",
+    name: "Test",
+    major: "Computer Science",
+    course: "CS1101S",
+    role: "student",
+  };
 
   beforeEach(() => {
     reqBody = getUpdateUserPasswordRequestBody();
@@ -447,131 +458,155 @@ describe('Unit Tests for /user/updateUserPassword endpoint', () => {
   });
 
   describe("Given a valid request body to update user password", () => {
-    it('Should return a success message', async () => {
+    it("Should return a success message", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByUserId').mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
+      jest
+        .spyOn(db, "getUserByUserId")
+        .mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
       bcrypt.compare = jest.fn().mockResolvedValue(true);
-      bcrypt.hash = jest.fn().mockResolvedValue('newhashedpassword');
-      jest.spyOn(db, 'updateUserPassword').mockResolvedValue();
+      bcrypt.hash = jest.fn().mockResolvedValue("newhashedpassword");
+      jest.spyOn(db, "updateUserPassword").mockResolvedValue();
 
       // Act
       const response = await supertest(app)
-        .put('/user/updateUserPassword')
+        .put("/user/updateUserPassword")
         .send(reqBody);
 
       // Assert
-      expect(response.body).toEqual({ message: 'Update password successfully.' });
+      expect(response.body).toEqual({
+        message: "Update password successfully.",
+      });
       expect(response.status).toBe(200);
     });
   });
 
   describe("Given a non-existing user", () => {
     it("Should return an error message", async () => {
-        // Arrange
-        jest.spyOn(db, "getUserByUserId").mockResolvedValue({ rows: [] } as unknown as QueryResult<any>);
+      // Arrange
+      jest
+        .spyOn(db, "getUserByUserId")
+        .mockResolvedValue({ rows: [] } as unknown as QueryResult<any>);
 
-        // Act
-        const response = await supertest(app)
-            .put("/user/updateUserPassword")
-            .send(reqBody);
+      // Act
+      const response = await supertest(app)
+        .put("/user/updateUserPassword")
+        .send(reqBody);
 
-        // Assert
-        expect(response.body).toEqual({ error: "User does not exist." });
-        // expect(response.status).toBe(400);
+      // Assert
+      expect(response.body).toEqual({ error: "User does not exist." });
+      // expect(response.status).toBe(400);
     });
   });
 
   describe("Given an incorrect old password", () => {
-    it('Should return an error message', async () => {
+    it("Should return an error message", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByUserId').mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
+      jest
+        .spyOn(db, "getUserByUserId")
+        .mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
       bcrypt.compare = jest.fn().mockResolvedValue(false);
 
       // Act
       const response = await supertest(app)
-        .put('/user/updateUserPassword')
+        .put("/user/updateUserPassword")
         .send(reqBody);
 
       // Assert
-      expect(response.body).toEqual({ error: 'Incorrect password.' });
+      expect(response.body).toEqual({ error: "Incorrect password." });
       // expect(response.status).toBe(400);
     });
   });
 
   describe("Given a failure to update user password", () => {
     it("Should return an error message", async () => {
-        // Arrange
-        jest.spyOn(db, "getUserByUserId").mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
-        bcrypt.compare = jest.fn().mockResolvedValue(true);
-        bcrypt.hash = jest.fn().mockResolvedValue('newhashedpassword');
-        jest.spyOn(db, "updateUserPassword").mockRejectedValue(new Error("Failed to update user password."));
+      // Arrange
+      jest
+        .spyOn(db, "getUserByUserId")
+        .mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
+      bcrypt.compare = jest.fn().mockResolvedValue(true);
+      bcrypt.hash = jest.fn().mockResolvedValue("newhashedpassword");
+      jest
+        .spyOn(db, "updateUserPassword")
+        .mockRejectedValue(new Error("Failed to update user password."));
 
-        // Act
-        const response = await supertest(app)
-            .put("/user/updateUserPassword")
-            .send(reqBody);
+      // Act
+      const response = await supertest(app)
+        .put("/user/updateUserPassword")
+        .send(reqBody);
 
-        // Assert
-        expect(response.body).toEqual({ error: "Failed to update user password." });
-        // expect(response.status).toBe(500);
+      // Assert
+      expect(response.body).toEqual({
+        error: "Failed to update user password.",
+      });
+      // expect(response.status).toBe(500);
     });
   });
 
   describe("Given an error while encrypting the new password", () => {
-    it('Should return a message indicating the error', async () => {
+    it("Should return a message indicating the error", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByUserId').mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
+      jest
+        .spyOn(db, "getUserByUserId")
+        .mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
       bcrypt.compare = jest.fn().mockResolvedValue(true);
-      bcrypt.hash = jest.fn().mockRejectedValue(new Error('Error crypting password.'));
+      bcrypt.hash = jest
+        .fn()
+        .mockRejectedValue(new Error("Error crypting password."));
 
       // Act
       const response = await supertest(app)
-        .put('/user/updateUserPassword')
+        .put("/user/updateUserPassword")
         .send(reqBody);
-  
+
       // Assert
-      expect(response.body).toEqual({ message: 'Error crypting password.' });
+      expect(response.body).toEqual({ message: "Error crypting password." });
       // expect(response.status).toBe(500);
     });
   });
 
   describe("Given an error while checking the password", () => {
-    it('Should return a message indicating the error', async () => {
+    it("Should return a message indicating the error", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByUserId').mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
-      bcrypt.compare = jest.fn().mockRejectedValue(new Error('Error checking password.'));
-  
+      jest
+        .spyOn(db, "getUserByUserId")
+        .mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
+      bcrypt.compare = jest
+        .fn()
+        .mockRejectedValue(new Error("Error checking password."));
+
       // Act
       const response = await supertest(app)
-        .put('/user/updateUserPassword')
+        .put("/user/updateUserPassword")
         .send(reqBody);
-  
+
       // Assert
-      expect(response.body).toEqual({ message: 'Error checking password.' });
+      expect(response.body).toEqual({ message: "Error checking password." });
       // expect(response.status).toBe(500);
     });
   });
-  
+
   describe("Given an error while getting the user by uid", () => {
-    it('Should return a message indicating the error', async () => {
+    it("Should return a message indicating the error", async () => {
       // Arrange
-      jest.spyOn(db, 'getUserByUserId').mockRejectedValue(new Error('Error getting user by uid.'));
-  
+      jest
+        .spyOn(db, "getUserByUserId")
+        .mockRejectedValue(new Error("Error getting user by uid."));
+
       // Act
       const response = await supertest(app)
-        .put('/user/updateUserPassword')
+        .put("/user/updateUserPassword")
         .send(reqBody);
-  
+
       // Assert
-      expect(response.body).toEqual({ message: 'Error getting user by uid.' });
+      expect(response.body).toEqual({ message: "Error getting user by uid." });
       // expect(response.status).toBe(500);
     });
   });
 });
 
-describe('Unit Tests for /user/updateUserInfo endpoint', () => {
+describe("Unit Tests for /user/updateUserInfo endpoint", () => {
   const app = createUnitTestServer();
-  let reqBody : any;
+  let reqBody: any;
 
   beforeEach(() => {
     reqBody = getUpdateUserInfoRequestBody();
@@ -582,13 +617,13 @@ describe('Unit Tests for /user/updateUserInfo endpoint', () => {
   });
 
   describe("Given a valid request body to update user info", () => {
-    it('Should return a success message', async () => {
+    it("Should return a success message", async () => {
       // Arrange
-      jest.spyOn(db, 'updateUserInfo').mockResolvedValue();
+      jest.spyOn(db, "updateUserInfo").mockResolvedValue();
 
       // Act
       const response = await supertest(app)
-        .put('/user/updateUserInfo')
+        .put("/user/updateUserInfo")
         .send(reqBody);
 
       // Assert
@@ -598,14 +633,16 @@ describe('Unit Tests for /user/updateUserInfo endpoint', () => {
   });
 
   describe("Given an invalid request body to update user info", () => {
-    it('Should return an error message', async () => {
+    it("Should return an error message", async () => {
       // Arrange
       const reqBody = {};
-      jest.spyOn(db, 'updateUserInfo').mockRejectedValue(new Error('Failed to update user info.'));
+      jest
+        .spyOn(db, "updateUserInfo")
+        .mockRejectedValue(new Error("Failed to update user info."));
 
       // Act
       const response = await supertest(app)
-        .put('/user/updateUserInfo')
+        .put("/user/updateUserInfo")
         .send(reqBody);
 
       // Assert
@@ -615,18 +652,18 @@ describe('Unit Tests for /user/updateUserInfo endpoint', () => {
   });
 });
 
-describe('Unit Tests for /user/deleteUser endpoint', () => {
+describe("Unit Tests for /user/deleteUser endpoint", () => {
   const app = createUnitTestServer();
-  let reqBody : any;
-  const user = { 
+  let reqBody: any;
+  const user = {
     uid: 1,
-    email: 'test@example.com',
-    password: 'password12345',
-    name: 'Test',
-    major: 'Computer Science',
-    course: 'CS1101S',
-    role: 'student',
-   };
+    email: "test@example.com",
+    password: "password12345",
+    name: "Test",
+    major: "Computer Science",
+    course: "CS1101S",
+    role: "student",
+  };
 
   beforeEach(() => {
     reqBody = getDeleteUserRequestBody();
@@ -637,13 +674,15 @@ describe('Unit Tests for /user/deleteUser endpoint', () => {
   });
 
   describe("Given a valid request body to delete a user", () => {
-    it('Should return a 200 status and a success message', async () => {
+    it("Should return a 200 status and a success message", async () => {
       // Arrange
-      jest.spyOn(db, 'deleteUser').mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
+      jest
+        .spyOn(db, "deleteUser")
+        .mockResolvedValue({ rows: [user] } as unknown as QueryResult<any>);
 
       // Act
       const response = await supertest(app)
-        .delete('/user/deleteUser')
+        .delete("/user/deleteUser")
         .send(reqBody);
 
       // Assert
@@ -653,24 +692,28 @@ describe('Unit Tests for /user/deleteUser endpoint', () => {
   });
 
   describe("Given an invalid request body to delete a user", () => {
-    it('Should return a 400 status and an error message', async () => {
+    it("Should return a 400 status and an error message", async () => {
       // Arrange
       const reqBody = {}; // Invalid request body
-      jest.spyOn(db, 'deleteUser').mockRejectedValue(new Error('Failed to delete user.'));
+      jest
+        .spyOn(db, "deleteUser")
+        .mockRejectedValue(new Error("Failed to delete user."));
 
       // Act
       const response = await supertest(app)
-        .delete('/user/deleteUser')
+        .delete("/user/deleteUser")
         .send(reqBody);
 
       // Assert
-      expect(response.body).toEqual({ error: "Undefined error deleting account." });
+      expect(response.body).toEqual({
+        error: "Undefined error deleting account.",
+      });
       // expect(response.status).toBe(400);
     });
   });
 });
 
-describe('Unit Tests for /user/clearCookie endpoint', () => {
+describe("Unit Tests for /user/clearCookie endpoint", () => {
   const app = createUnitTestServer();
 
   afterEach(() => {
@@ -679,12 +722,13 @@ describe('Unit Tests for /user/clearCookie endpoint', () => {
 
   it('Should clear the "token" cookie and return a success message', async () => {
     // Act
-    const response = await supertest(app)
-      .delete('/user/clearCookie');
+    const response = await supertest(app).delete("/user/clearCookie");
 
     // Assert
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({ message: 'Cleared user cookie' });
-    expect(response.headers['set-cookie']).toEqual(['token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT']);
+    expect(response.body).toEqual({ message: "Cleared user cookie" });
+    expect(response.headers["set-cookie"]).toEqual([
+      "token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+    ]);
   });
 });

--- a/backend/user-service/tests/unit/model/user-model.test.ts
+++ b/backend/user-service/tests/unit/model/user-model.test.ts
@@ -1,28 +1,31 @@
-import { QueryResult } from 'pg';
-import pool from '../../../psql';
-import model from '../../../models/user-model';
+import { QueryResult } from "pg";
+import pool from "../../../psql";
+import model from "../../../models/user-model";
 
-jest.mock('../../../psql', () => ({
+process.env.NODE_ENV = "test";
+
+jest.mock("../../../psql", () => ({
   query: jest.fn(),
+  connect: jest.fn(),
 }));
 
-describe('getAllUsers function', () => {
+describe("getAllUsers function", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return all users', async () => {
+  it("should return all users", async () => {
     // Arrange
     const mockResult = {
       rows: [
         {
           uid: 1,
-          email: 'test@example.com',
-          password: 'password12345',
-          name: 'Test',
-          major: 'Computer Science',
-          course: 'CS1101S',
-          role: 'student',
+          email: "test@example.com",
+          password: "password12345",
+          name: "Test",
+          major: "Computer Science",
+          course: "CS1101S",
+          role: "student",
         },
       ],
     };
@@ -35,9 +38,9 @@ describe('getAllUsers function', () => {
     expect(result).toEqual(mockResult.rows);
   });
 
-  it('should throw an error if query fails', async () => {
+  it("should throw an error if query fails", async () => {
     // Arrange
-    const errorMessage = 'Failed to fetch users';
+    const errorMessage = "Failed to fetch users";
     (pool.query as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
     // Act and Assert
@@ -45,24 +48,24 @@ describe('getAllUsers function', () => {
   });
 });
 
-describe('getUserByUserId function', () => {
+describe("getUserByUserId function", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return a user by userId', async () => {
+  it("should return a user by userId", async () => {
     // Arrange
     const uid = 1;
     const mockResult = {
       rows: [
         {
           uid: 1,
-          email: 'test@example.com',
-          password: 'password12345',
-          name: 'Test',
-          major: 'Computer Science',
-          course: 'CS1101S',
-          role: 'student',
+          email: "test@example.com",
+          password: "password12345",
+          name: "Test",
+          major: "Computer Science",
+          course: "CS1101S",
+          role: "student",
         },
       ],
     };
@@ -75,10 +78,10 @@ describe('getUserByUserId function', () => {
     expect(result).toEqual(mockResult);
   });
 
-  it('should throw an error if query fails', async () => {
+  it("should throw an error if query fails", async () => {
     // Arrange
     const uid = 1;
-    const errorMessage = 'Failed to fetch user';
+    const errorMessage = "Failed to fetch user";
     (pool.query as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
     // Act and Assert
@@ -86,24 +89,24 @@ describe('getUserByUserId function', () => {
   });
 });
 
-describe('getUserByEmail function', () => {
+describe("getUserByEmail function", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return a user by email', async () => {
+  it("should return a user by email", async () => {
     // Arrange
-    const email = 'test@example.com';
+    const email = "test@example.com";
     const mockResult = {
       rows: [
         {
           uid: 1,
-          email: 'test@example.com',
-          password: 'password12345',
-          name: 'Test',
-          major: 'Computer Science',
-          course: 'CS1101S',
-          role: 'student',
+          email: "test@example.com",
+          password: "password12345",
+          name: "Test",
+          major: "Computer Science",
+          course: "CS1101S",
+          role: "student",
         },
       ],
     };
@@ -116,10 +119,10 @@ describe('getUserByEmail function', () => {
     expect(result).toEqual(mockResult);
   });
 
-  it('should throw an error if query fails', async () => {
+  it("should throw an error if query fails", async () => {
     // Arrange
-    const email = 'test@example.com';
-    const errorMessage = 'Failed to fetch user';
+    const email = "test@example.com";
+    const errorMessage = "Failed to fetch user";
     (pool.query as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
     // Act and Assert
@@ -127,62 +130,72 @@ describe('getUserByEmail function', () => {
   });
 });
 
-describe('updateUser function', () => {
+describe("updateUser function", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-  
-  it('should update a user', async () => {
+
+  it("should update a user", async () => {
     // Arrange
     const uid = 1;
-    const name = 'Updated Name';
-    const major = 'Updated Major';
-    const course = 'Updated Course';
-    const email = 'updated@example.com';
-    const hash = 'updatedHash';
-    const role = 'updatedRole';
+    const name = "Updated Name";
+    const major = "Updated Major";
+    const course = "Updated Course";
+    const email = "updated@example.com";
+    const hash = "updatedHash";
+    const role = "updatedRole";
 
     const mockResult = {
       rowCount: 1,
     };
     (pool.query as jest.Mock).mockResolvedValue(mockResult as QueryResult);
     // Act
-    const result = await model.updateUser(uid, name, major, course, email, hash, role);
+    const result = await model.updateUser(
+      uid,
+      name,
+      major,
+      course,
+      email,
+      hash,
+      role
+    );
 
     // Assert
     expect(result).toBeUndefined();
   });
 
-  it('should throw an error if query fails', async () => {
+  it("should throw an error if query fails", async () => {
     // Arrange
     const uid = 1;
-    const name = 'Updated Name';
-    const major = 'Updated Major';
-    const course = 'Updated Course';
-    const email = 'updated@example.com';
-    const hash = 'updatedHash';
-    const role = 'updatedRole';
-    const errorMessage = 'Failed to update user';
+    const name = "Updated Name";
+    const major = "Updated Major";
+    const course = "Updated Course";
+    const email = "updated@example.com";
+    const hash = "updatedHash";
+    const role = "updatedRole";
+    const errorMessage = "Failed to update user";
     (pool.query as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
     // Act and Assert
-    await expect(model.updateUser(uid, name, major, course, email, hash, role)).rejects.toThrow(errorMessage);
+    await expect(
+      model.updateUser(uid, name, major, course, email, hash, role)
+    ).rejects.toThrow(errorMessage);
   });
 });
 
-describe('createNewUser function', () => {
+describe("createNewUser function", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should create a new user and return the user ID', async () => {
+  it("should create a new user and return the user ID", async () => {
     // Arrange
-    const name = 'New User';
-    const major = 'Computer Science';
-    const course = 'CS1101S';
-    const email = 'newuser@example.com';
-    const hash = 'newHash';
-    const role = 'student';
+    const name = "New User";
+    const major = "Computer Science";
+    const course = "CS1101S";
+    const email = "newuser@example.com";
+    const hash = "newHash";
+    const role = "student";
 
     const mockResult = {
       rows: [{ uid: 1 }],
@@ -190,37 +203,46 @@ describe('createNewUser function', () => {
     (pool.query as jest.Mock).mockResolvedValue(mockResult as QueryResult);
 
     // Act
-    const result = await model.createNewUser(name, major, course, email, hash, role);
+    const result = await model.createNewUser(
+      name,
+      major,
+      course,
+      email,
+      hash,
+      role
+    );
 
     // Assert
     expect(result).toBe(1);
   });
 
-  it('should throw an error if query fails', async () => {
+  it("should throw an error if query fails", async () => {
     // Arrange
-    const name = 'New User';
-    const major = 'Computer Science';
-    const course = 'CS1101S';
-    const email = 'newuser@example.com';
-    const hash = 'newHash';
-    const role = 'student';
-    const errorMessage = 'Failed to create user';
+    const name = "New User";
+    const major = "Computer Science";
+    const course = "CS1101S";
+    const email = "newuser@example.com";
+    const hash = "newHash";
+    const role = "student";
+    const errorMessage = "Failed to create user";
     (pool.query as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
     // Act and Assert
-    await expect(model.createNewUser(name, major, course, email, hash, role)).rejects.toThrow(errorMessage);
+    await expect(
+      model.createNewUser(name, major, course, email, hash, role)
+    ).rejects.toThrow(errorMessage);
   });
 });
 
-describe('updateUserPassword function', () => {
+describe("updateUserPassword function", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should update a user\'s password', async () => {
+  it("should update a user's password", async () => {
     // Arrange
     const uid = 1;
-    const hash = 'newHash';
+    const hash = "newHash";
 
     const mockResult = {
       rowCount: 1,
@@ -234,31 +256,33 @@ describe('updateUserPassword function', () => {
     expect(result).toBeUndefined();
   });
 
-  it('should throw an error if query fails', async () => {
+  it("should throw an error if query fails", async () => {
     // Arrange
     const uid = 1;
-    const hash = 'newHash';
-    const errorMessage = 'Failed to update password';
+    const hash = "newHash";
+    const errorMessage = "Failed to update password";
     (pool.query as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
     // Act and Assert
-    await expect(model.updateUserPassword(uid, hash)).rejects.toThrow(errorMessage);
+    await expect(model.updateUserPassword(uid, hash)).rejects.toThrow(
+      errorMessage
+    );
   });
 });
 
-describe('updateUserInfo function', () => {
+describe("updateUserInfo function", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should update user information', async () => {
+  it("should update user information", async () => {
     // Arrange
     const uid = 1;
-    const email = 'updated@example.com';
-    const name = 'Updated Name';
-    const major = 'Updated Major';
-    const course = 'Updated Course';
-    const role = 'Updated Role';
+    const email = "updated@example.com";
+    const name = "Updated Name";
+    const major = "Updated Major";
+    const course = "Updated Course";
+    const role = "Updated Role";
 
     const mockResult = {
       rowCount: 1,
@@ -266,35 +290,43 @@ describe('updateUserInfo function', () => {
     (pool.query as jest.Mock).mockResolvedValue(mockResult as QueryResult);
 
     // Act
-    const result = await model.updateUserInfo(uid, email, name, major, course, role);
+    const result = await model.updateUserInfo(
+      uid,
+      email,
+      name,
+      major,
+      course,
+      role
+    );
 
     // Assert
     expect(result).toBeUndefined();
   });
 
-  it('should throw an error if update fails', async () => {
+  it("should throw an error if update fails", async () => {
     // Arrange
     const uid = 1;
-    const email = 'updated@example.com';
-    const name = 'Updated Name';
-    const major = 'Updated Major';
-    const course = 'Updated Course';
-    const role = 'Updated Role';
-    const errorMessage = 'Failed to update user';
+    const email = "updated@example.com";
+    const name = "Updated Name";
+    const major = "Updated Major";
+    const course = "Updated Course";
+    const role = "Updated Role";
+    const errorMessage = "Failed to update user";
     (pool.query as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
     // Act and Assert
-    await expect(model.updateUserInfo(uid, email, name, major, course, role)).rejects.toThrow(errorMessage);
+    await expect(
+      model.updateUserInfo(uid, email, name, major, course, role)
+    ).rejects.toThrow(errorMessage);
   });
 });
 
-
-describe('deleteUser function', () => {
+describe("deleteUser function", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should delete a user', async () => {
+  it("should delete a user", async () => {
     // Arrange
     const uid = 1;
 
@@ -310,10 +342,10 @@ describe('deleteUser function', () => {
     expect(result).toEqual(mockResult);
   });
 
-  it('should throw an error if query fails', async () => {
+  it("should throw an error if query fails", async () => {
     // Arrange
     const uid = 1;
-    const errorMessage = 'Failed to delete user';
+    const errorMessage = "Failed to delete user";
     (pool.query as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
     // Act and Assert

--- a/backend/user-service/yarn.lock
+++ b/backend/user-service/yarn.lock
@@ -1093,7 +1093,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-anymatch@^3.0.3:
+anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -1224,6 +1224,11 @@ bcrypt@^5.1.1:
     "@mapbox/node-pre-gyp" "^1.0.11"
     node-addon-api "^5.0.0"
 
+binary-extensions@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
+  integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
 body-parser@1.20.2:
   version "1.20.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
@@ -1257,7 +1262,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1360,6 +1365,21 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+chokidar@^3.5.2:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -1533,7 +1553,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2023,7 +2043,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -2079,7 +2099,7 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2226,6 +2246,11 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ignore-by-default@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+  integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
+
 ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
@@ -2275,6 +2300,13 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-core-module@^2.13.0:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
@@ -2297,7 +2329,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -3093,6 +3125,22 @@ node-releases@^2.0.14:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
+nodemon@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-3.1.0.tgz#ff7394f2450eb6a5e96fe4180acd5176b29799c9"
+  integrity sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==
+  dependencies:
+    chokidar "^3.5.2"
+    debug "^4"
+    ignore-by-default "^1.0.1"
+    minimatch "^3.1.2"
+    pstree.remy "^1.1.8"
+    semver "^7.5.3"
+    simple-update-notifier "^2.0.0"
+    supports-color "^5.5.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.5"
+
 nopt@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
@@ -3100,7 +3148,14 @@ nopt@^5.0.0:
   dependencies:
     abbrev "1"
 
-normalize-path@^3.0.0:
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  integrity sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==
+  dependencies:
+    abbrev "1"
+
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -3341,7 +3396,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3442,6 +3497,11 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+pstree.remy@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
+  integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
+
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
@@ -3499,6 +3559,13 @@ readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -3655,6 +3722,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+simple-update-notifier@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz#d70b92bdab7d6d90dfd73931195a30b6e3d7cebb"
+  integrity sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==
+  dependencies:
+    semver "^7.5.3"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -3770,7 +3844,7 @@ supertest@^6.3.4:
     methods "^1.1.2"
     superagent "^8.1.2"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -3843,6 +3917,13 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+touch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  integrity sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
+  dependencies:
+    nopt "~1.0.10"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -3921,6 +4002,11 @@ typescript@^5.4.2:
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
   integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
+
+undefsafe@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
+  integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
# Pull Request

## Description
<!-- [Provide a brief description of the changes introduced by this PR. Explain the problem it solves or the feature it adds.] -->
As previously mentioned, all other table names are like `Assignment`, `Submission`, `Question`, etc. format, and the user table was `users`. This also raises complication for referencing the table in Prisma. Therefore, for consistency and to prevent complexity, I change the user table name to `User`. 

## Related Issue(s)
<!-- [Link to any related issues or tasks, e.g., "Closes #123" or "Fixes #456."] -->

## Screenshots (if applicable)
<!-- [Include screenshots or images to visually showcase the changes, if applicable.] -->

## Checklist

- [x] I have checked that the changes included in the PR are intended to merge to `master` or any destination branch.
- [x] I have verified that the new changes do not break any existing functionalities, unless the new changes are intended and have approved by the team.
- [x] I will take care of the merging and delete the side-branch after the PR is merged.

## Additional Notes/References
<!-- [Add any additional notes, comments, or context that might be helpful for reviewers or future reference.] -->
Please merge this ASAP as it is blocking many PRs to update and the user table might keep getting created and deleted... If this doesn't get reviewed by 9 Apr 2024, 12PM, I will force merge to master.
